### PR TITLE
Filter out artificial click events

### DIFF
--- a/offClick.js
+++ b/offClick.js
@@ -36,6 +36,10 @@ angular.module('offClick',[])
             });
 
             function handler(event) {
+                // This filters out artificial click events. Example: If you hit enter on a form to submit it, an
+                // artificial click event gets triggered on the form's submit button.
+                if (event.pageX == 0 && event.pageY == 0) return;
+                
                 var target = event.target || event.srcElement;
                 if (!(elm[0].contains(target) || targetInFilter(target, attr.offClickFilter))) {
                     scope.$apply(scope.offClick());


### PR DESCRIPTION
I encountered this when working on a form that you can submit by hitting "enter". It seems to trigger an artificial click event on the form's submit button (see here: http://stackoverflow.com/questions/11760030/click-event-on-button-is-trigged-when-submitting-a-form-with-enter). The only difference I could see between this event and an actual click event is that the pageX and pageY on the artificial one were 0. I don't know if there are other circumstances in which these click events would be triggered, but I think ignoring them is the less surprising behavior.
