### PR TITLE
align off-click-if with developer expectations

### DIFF
--- a/offClick.js
+++ b/offClick.js
@@ -1,5 +1,5 @@
 angular.module('offClick',[])
-.directive('offClick', ['$document', function ($document) {
+.directive('offClick', ['$document', '$timeout', function ($document, $timeout) {
         
     function targetInFilter(target,filter){
         if(!target || !filter) return false;
@@ -21,7 +21,9 @@ angular.module('offClick',[])
             if (attr.offClickIf) {
                 scope.$watch(scope.offClickIf, function (newVal, oldVal) {
                         if (newVal && !oldVal) {
-                            $document.on('click', handler);
+                            $timeout(function() {
+                                $document.on('click', handler);
+                            });
                         } else if(!newVal){
                             $document.off('click', handler);
                         }


### PR DESCRIPTION
This PR fixes the issue illustrated in [this plunkr](http://plnkr.co/edit/8vnPWWbhRs7hSq3dlKLu?p=preview), without having to use the off-click-filter feature.  Compare to [this fixed plunkr](http://plnkr.co/edit/nzOzYrNeXyQlIvUJzVUz?p=preview).

There is a work around here, using the off-click-filter feature.  But I think we can do better, aligning the feature with common developer expectations.  The developer is probably expecting the off-click-if to not activate until after the click event has completed, which caused the watched variable to change to true.  We can do this by means of a timeout of 0 which causes the the document click handler to be created immediately after the current digest cycle.  I feel this approach aligns more with the developer's expectations of off-click-if.
