### PR TITLE
don't polute namespace

### DIFF
--- a/offClick.js
+++ b/offClick.js
@@ -20,14 +20,14 @@ angular.module('offClick', [])
                     $rootScope.$watch(attr.offClickIf, function (newVal, oldVal) {
                         if (newVal && !oldVal) {
                             $timeout(function () {
-                                $document.on('click', handler);
+                                $document.on('click.offclick', handler);
                             });
                         } else if (!newVal) {
-                            $document.off('click', handler);
+                            $document.off('click.offclick', handler);
                         }
                     });
                 } else {
-                    $document.on('click', handler);
+                    $document.on('click.offclick', handler);
                 }
 
                 attr.$observe('offClickFilter', function (value) {


### PR DESCRIPTION
`$document.off('click', handler)` will remove **ALL** event's of the type `click` on `document`, working in a large codebase, chances are that more events could be bound by `$document.on('click', handler)` (reference: [http://api.jquery.com/off/](http://api.jquery.com/off/))

I suggest to add a default namespace like the proposed, or even an attribute assigning a namespace per binding
```html 
<div off-click-namespace="offclick"></div>
``` 
If you wanna go all in, you could also use a provider in the config phase as in:

```js
app.config(function($offClickProvider) {
   angular.extend($offClickProvider.defaults, {
         namespace: 'offclick'
   });
});
```