### PR TITLE
Revert "don't polute namespace"

### DIFF
--- a/offClick.js
+++ b/offClick.js
@@ -20,14 +20,14 @@ angular.module('offClick', [])
                     $rootScope.$watch(attr.offClickIf, function (newVal, oldVal) {
                         if (newVal && !oldVal) {
                             $timeout(function () {
-                                $document.on('click.offclick', handler);
+                                $document.on('click', handler);
                             });
                         } else if (!newVal) {
-                            $document.off('click.offclick', handler);
+                            $document.off('click', handler);
                         }
                     });
                 } else {
-                    $document.on('click.offclick', handler);
+                    $document.on('click', handler);
                 }
 
                 attr.$observe('offClickFilter', function (value) {


### PR DESCRIPTION
Reverts TheSharpieOne/angular-off-click#12 as jQlite does not support namespaces