### PR TITLE
Fix for filter: IE throws exception on element.contains() if element is a DOM node but not an element

### DIFF
--- a/offClick.js
+++ b/offClick.js
@@ -9,8 +9,7 @@ angular.module('offClick', [])
     function targetInFilter(target, elms) {
         if (!target || !elms) return false;
         var elmsLen = elms.length;
-        for (var i = 0; i < elmsLen; ++i)
-        if (elms[i].contains(target)) {
+        for (var i = 0; i < elmsLen; ++i) {
             var currentElem = elms[i];
             var containsTarget = false;
             try {

--- a/offClick.js
+++ b/offClick.js
@@ -10,7 +10,24 @@ angular.module('offClick', [])
         if (!target || !elms) return false;
         var elmsLen = elms.length;
         for (var i = 0; i < elmsLen; ++i)
-        if (elms[i].contains(target)) return true;
+        if (elms[i].contains(target)) {
+            var currentElem = elms[i];
+            var containsTarget = false;
+            try {
+                containsTarget = currentElem.contains(target);
+            } catch (e) {
+                // If the node is not an Element (e.g., an SVGElement) node.contains() throws Exception in IE,
+                // see https://connect.microsoft.com/IE/feedback/details/780874/node-contains-is-incorrect
+                // In this case we use compareDocumentPosition() instead.
+                if (typeof currentElem.compareDocumentPosition !== 'undefined') {
+                    containsTarget = currentElem === target || Boolean(currentElem.compareDocumentPosition(target) & 16);
+                }
+            }
+
+            if (containsTarget) {
+                return true;
+            }
+        }
         return false;
     }
 


### PR DESCRIPTION
If one of the filter elements is a DOM node like an SVG element (apparently), Internet Explorer throws the following Error: "JavaScript runtime error: Object doesn't support property or method 'contains'"

See https://connect.microsoft.com/IE/feedback/details/780874/node-contains-is-incorrect

This PR fixes this issue by catching the exception and using an alternate implementation using compareDocumentPosition().